### PR TITLE
feat: rename CV and add tabbed layout versions

### DIFF
--- a/PeterMacHamilton.html
+++ b/PeterMacHamilton.html
@@ -3,32 +3,40 @@
 <head>
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
-  <meta name="keywords" content="Product Manager Sênior, Growth, Saúde Digital, Prescrição, GA4, BigQuery, Salesforce Marketing Cloud, HubSpot, A/B testing, Cohort Analysis, CAC, LTV, Churn, PLG">
   <title>Currículo de Peter Mac Hamilton</title>
   <link rel="stylesheet" href="style.css">
+  <style>
+    /* Estilo específico para organizar certificados de cursos em 3 colunas com fonte menor */
+    .cv-page .three-columns {
+      display: grid;
+      grid-template-columns: repeat(3, 1fr);
+      gap: 10px;
+      font-size: 0.85em;
+    }
+    .cv-page .three-columns ul {
+      list-style-type: none;
+      padding-left: 0;
+    }
+    .cv-page .three-columns li {
+      margin-bottom: 5px;
+    }
+  </style>
 </head>
 <body class="cv-page">
   <div class="container">
     <!-- Dados Pessoais -->
     <header>
       <h1>Peter Mac Hamilton</h1>
-      <p><strong>PM Sênior | Growth & Saúde Digital | Prescrição | GA4/BigQuery · Salesforce MC · A/B · Cohorts</strong></p>
+      <p><strong>Product Manager | Estratégia e Inovação em Produtos Digitais</strong></p>
       <p>São Paulo, SP | 11 96953-4105 | <a href="mailto:novoemaildopeter@gmail.com">novoemaildopeter@gmail.com</a> | <a href="https://www.linkedin.com/in/peter-mac-hamilton" target="_blank">linkedin.com/in/peter-mac-hamilton/</a></p>
     </header>
     
-    <!-- Resumo -->
-    <section id="summary">
-      <h2>Resumo</h2>
-      <p>PM Sênior focado em Growth. Defino North Star, instrumento jornada e rodo experimentos para aquisição, ativação, engajamento e retenção. Entregas: −70% no Time-to-First-Value, −50% em tickets, 10k+ alunos em modelo recorrente. Stack: GA4/BigQuery, Salesforce Marketing Cloud, HubSpot, A/B testing e cohorts.</p>
-    </section>
-
+    <!-- Objetivo Profissional -->
     <section>
-      <h2>Impacto em 3 bullets</h2>
-      <ul>
-        <li>−70% no tempo até primeiro valor (onboarding guiado + base de conhecimento).</li>
-        <li>POC Rx→Compra: telemetria + CRM/MC para fechar campanha → produto → venda (LGPD-safe).</li>
-        <li>10k+ alunos em EdTech com modelo recorrente; +120% em vendas online em projeto correlato.</li>
-      </ul>
+      <h2>Objetivo Profissional</h2>
+      <p>
+        Profissional experiente em gestão de produtos digitais, com forte atuação na implementação de metodologias ágeis, definição de roadmaps e estratégias baseadas em dados, além da condução de pesquisas e benchmarkings. Com histórico de transformar desafios em soluções inovadoras, atuo na liderança de times multidisciplinares, integrando UX, dados, tecnologia e áreas de negócio. Busco contribuir para a transformação digital, agregando valor a produtos que impactem positivamente a experiência dos usuários.
+      </p>
     </section>
     
     <!-- Experiência Profissional -->
@@ -36,30 +44,45 @@
       <h2>Experiência Profissional</h2>
       
       <div class="job">
-        <h3>PremieRpet — Senior Product Manager (nov/2024 – presente) · São Paulo · B2B2C/Healthtech</h3>
+        <h3>Product Manager - PremieRpet</h3>
+        <p><em>Novembro de 2024 – Presente | São Paulo, SP</em></p>
         <ul>
-          <li>Defini <strong>North Star</strong> (prescrições/médico/semana) e <strong>TTFP</strong> como leading metric; instrumentação <strong>GA4 → BigQuery</strong> em todo o fluxo.</li>
-          <li><strong>Backlog de experimentos</strong> (A/B) em onboarding de prescrição, busca/posologia e CTAs; <strong>coortes</strong> por especialidade/região.</li>
-          <li><strong>Lifecycle</strong>: ativação e reativação com <strong>Salesforce Marketing Cloud/HubSpot</strong>; acompanhamento de <strong>retenção D7/D30</strong>.</li>
-          <li><strong>Integrações</strong>: MC (journeys) e POC <strong>Rx → Compra</strong> cruzando CRM/Exclusive (hash LGPD-safe).</li>
+          <li>Liderança na criação e gestão de produtos digitais para o setor pet, com foco em inovação e excelência na experiência do usuário.</li>
+          <li>Implementação de metodologias ágeis para otimização dos processos internos e aceleração dos ciclos de desenvolvimento.</li>
+          <li>Definição de estratégias baseadas em dados para embasar decisões e monitorar métricas essenciais.</li>
+          <li>Coordenação de equipes multidisciplinares, garantindo alinhamento entre UX, dados, tecnologia e áreas de negócio.</li>
         </ul>
       </div>
-
+      
       <div class="job">
-        <h3>Gedanken (GCertifica) — Product Manager (mai/2022 – nov/2024) · São Paulo · B2B SaaS</h3>
+        <h3>Product Manager - Gedanken</h3>
+        <p><em>Maio de 2022 – Outubro de 2024 | São Paulo, SP</em></p>
         <ul>
-          <li>Redesenho de <strong>onboarding</strong> e padronização de entregas; <strong>base de conhecimento</strong> e autoatendimento.</li>
-          <li>Experimentos contínuos no funil (copy/CTA/fluxo) e <strong>coortes por canal</strong>.</li>
-          <li><strong>Resultados</strong>: <strong>−70% TTFV</strong>, <strong>−50% tickets</strong>, <strong>NPS ↑</strong>, <strong>churn ↓</strong>.</li>
+          <li>Implementação de metodologias ágeis (SCRUM e Kanban) para otimização de processos internos e aumento da eficiência.</li>
+          <li>Coordenação de iniciativas inovadoras, resultando na elevação do NPS e redução do churn.</li>
+          <li>Desenvolvimento e gestão de uma base de conhecimento que reduziu em 50% os tickets de suporte.</li>
+          <li>Redesenho de processos e padronização de produtos, diminuindo o Time to First Value (TFV) em 70%.</li>
         </ul>
       </div>
-
+      
       <div class="job">
-        <h3>Se Liga (EdTech) — Product Manager (jul/2017 – mai/2022) · B2C assinatura</h3>
+        <h3>Product Manager - Se Liga (EdTech)</h3>
+        <p><em>Julho de 2017 – Maio de 2022 | São Paulo, SP</em></p>
         <ul>
-          <li>Virada de conteúdo gratuito para <strong>modelo recorrente</strong>; construção do <strong>LMS</strong>.</li>
-          <li>Testes em <strong>landing/paywall</strong> para <strong>aquisição → conversão</strong> e <strong>rituais</strong> de uso para <strong>retenção</strong>.</li>
-          <li><strong>Resultados</strong>: <strong>10k+ alunos</strong>; <strong>+120%</strong> em vendas online em projeto correlato.</li>
+          <li>Transformação de um canal do YouTube em uma EdTech com mais de 10 mil alunos.</li>
+          <li>Criação de um LMS do zero com mais de 10 mil alunos e sistema de gameficação.</li>
+          <li>Conversão de conteúdo gratuito para cursos pagos, gerando crescimento expressivo da receita.</li>
+          <li>Implementação de modelo de assinatura, consolidando um negócio sustentável e lucrativo.</li>
+        </ul>
+      </div>
+      
+      <div class="job">
+        <h3>Product Owner - Editora Lorca</h3>
+        <p><em>Fevereiro de 2015 – Junho de 2017 | São Paulo, SP</em></p>
+        <ul>
+          <li>Criação de uma interface global de vendas, que aumentou as vendas online em 120%.</li>
+          <li>Implementação de modelo de vendas digitais, gerando um aumento de 12% no faturamento.</li>
+          <li>Gerenciamento de equipes internacionais, com atuação em espanhol e inglês.</li>
         </ul>
       </div>
     </section>
@@ -76,26 +99,76 @@
       </ul>
     </section>
     
-    <!-- Competências & Stack -->
+    <!-- Competências Técnicas -->
     <section>
-      <h2>Competências & Stack</h2>
+      <h2>Competências Técnicas</h2>
       <ul>
-        <li><strong>Growth/Métricas</strong>: Funil, <strong>CAC</strong>, <strong>LTV</strong>, <strong>churn</strong>, <strong>retenção D7/D30</strong>, <strong>WAU/MAU</strong>, <strong>cohorts</strong>.</li>
-        <li><strong>Experimentos</strong>: <strong>A/B testing</strong>, hipóteses, <strong>ICE/PIE</strong>, <strong>North Star</strong>, <strong>TTFP/TTFV</strong>.</li>
-        <li><strong>Dados/Martech</strong>: <strong>GA4</strong>, <strong>BigQuery</strong>, <strong>Amplitude</strong>, <strong>Segment</strong>, <strong>HubSpot</strong>, <strong>Salesforce MC</strong>, <strong>RD Station</strong>.</li>
-        <li><strong>Produto/UX</strong>: <strong>Discovery</strong>, <strong>Jira</strong>, <strong>OKRs</strong>, <strong>Figma</strong>, <strong>Miro</strong>; <strong>Zendesk</strong> (base de conhecimento).</li>
-        <li><strong>Linguagens/Outros</strong>: SQL básico; GitHub (issues).</li>
+        <li><strong>Metodologias Ágeis:</strong> SCRUM, Kanban, liderança de squads e otimização de entregas.</li>
+        <li><strong>Gestão de Produtos:</strong> Definição de roadmaps, priorização de backlog e ciclo de vida completo do produto.</li>
+        <li><strong>Ferramentas:</strong> Jira, SQL, Figma, Adobe XD – para prototipação e análise de dados.</li>
+        <li><strong>Análise de Dados:</strong> Data Analytics, Business Intelligence, e uso de métricas (NPS, LTV, churn) para decisões estratégicas.</li>
+        <li><strong>Liderança e Comunicação:</strong> Gestão de equipes cross-funcionais e alinhamento com stakeholders.</li>
       </ul>
     </section>
     
-    <section>
-      <h2>Certificações</h2>
-      <ul>
-        <li>CSPO — K21</li>
-        <li>Digital Product Leadership — TERA</li>
-        <li>Inteligência Artificial em Negócios Digitais — TERA</li>
-      </ul>
-    </section>
+  <!-- Certificações e Cursos -->
+<section>
+  <h2>Certificações e Cursos</h2>
+  
+<!-- Certificados de Formações -->
+<h3>Certificados de Formações</h3>
+<p style="font-size: 0.9em; color: #555;">Certificados obtidos na TERA e K21</p>
+<ul>
+  <li>
+    <strong>Certified Scrum Product Owner (CSPO)</strong><br>
+    Certificação que valida o conhecimento e a prática de métodos ágeis, com foco na gestão de produtos e priorização do backlog, obtida na K21.<br>
+    <a href="https://bcert.me/bc/html/show-badge.html?b=njanhueg" target="_blank">Ver certificado</a>
+  </li>
+  <li>
+    <strong>Inteligência Artificial em Negócios Digitais</strong><br>
+    Curso focado em estratégias para aplicar inteligência artificial na transformação digital, explorando casos práticos e métricas de performance.<br>
+    <a href="https://credentials.somostera.com/83740b7a0e44eb65e6487cb7b8c68e39" target="_blank">Ver certificado</a>
+  </li>
+  <li>
+    <strong>Product Discovery</strong><br>
+    Formação que ensina metodologias e práticas para identificar oportunidades de mercado e validar conceitos de produtos digitais por meio de pesquisa e experimentação.<br>
+    <a href="https://credentials.somostera.com/ce19894af5cfc4135e68d29c1c6bcce5" target="_blank">Ver certificado</a>
+  </li>
+  <li>
+    <strong>Digital Product Leadership</strong><br>
+    Curso voltado para o desenvolvimento de competências em liderança e gestão estratégica de produtos digitais, integrando inovação e melhores práticas de mercado.<br>
+    <a href="https://credentials.somostera.com/5a72983344edef6c1112b86f9289ff4a" target="_blank">Ver certificado</a>
+  </li>
+</ul>
+
+
+  
+  <!-- Certificados de Cursos distribuídos em três colunas -->
+  <h3>Certificados de Cursos</h3>
+  <div class="three-columns">
+    <ul>
+      <li><a href="https://credentials.somostera.com/1d013eb7247265683f356885fadc8396" target="_blank">Introdução a Product Discovery</a></li>
+      <li><a href="https://credentials.somostera.com/29acaf7980f01294edc0ef69e1a8398e" target="_blank">Plano estratégico para investimento em IA</a></li>
+      <li><a href="https://credentials.somostera.com/3e484c44a9bcba79960779480d7de4c2" target="_blank">Introdução ao Discovery Contínuo</a></li>
+      <li><a href="https://credentials.somostera.com/41674ca4aae5ea1e870e13f2e4b08da9" target="_blank">Ideação e Teste de Soluções</a></li>
+      <li><a href="https://credentials.somostera.com/4ccc88ad1ddee29ea084c064587a6abe" target="_blank">Liderança e Negociação</a></li>
+    </ul>
+    <ul>
+      <li><a href="https://credentials.somostera.com/61f9ecf27003646aa73f962d94fe8fd9" target="_blank">Implementação ágil de IA Generativa</a></li>
+      <li><a href="https://credentials.somostera.com/69b67b6f0454995797df1e88ba500f7c" target="_blank">Pesquisa para PMs</a></li>
+      <li><a href="https://credentials.somostera.com/7aece7e4db69ddbe6de5d158b6b67f22" target="_blank">Fundamentos da IA Generativa</a></li>
+      <li><a href="https://credentials.somostera.com/a8580d374cf9328bbae83d57662eb75b" target="_blank">Métricas e tomada de decisão com dados</a></li>
+      <li><a href="https://credentials.somostera.com/afbbc26e0ed50da5b0f31c2d153543a8" target="_blank">Aplique os resultados do Discovery</a></li>
+    </ul>
+    <ul>
+      <li><a href="https://credentials.somostera.com/bb8de389cfd34396f006e14bfa79eb1a" target="_blank">Métricas para Produtos Digitais</a></li>
+      <li><a href="https://credentials.somostera.com/d3a0fd52efad3d87d638c21b52144f57" target="_blank">Planejamento de Product Discovery</a></li>
+      <li><a href="https://credentials.somostera.com/ddc6f994c2417e8105e00b34e91fe0a0" target="_blank">Fundamentos de Product Management</a></li>
+      <li><a href="https://credentials.somostera.com/e654c0274028ef280eb5a13c42bbcadc" target="_blank">Definição e Validação do problema</a></li>
+      <li><a href="https://credentials.somostera.com/e8d23951e4b861a81e73e850dc46cc3c" target="_blank">Product Delivery: Construa a solução</a></li>
+    </ul>
+  </div>
+</section>
 
     
     <!-- Idiomas -->

--- a/SeniorProductManager.html
+++ b/SeniorProductManager.html
@@ -6,9 +6,31 @@
   <meta name="keywords" content="Product Manager Sênior, Growth, Saúde Digital, Prescrição, GA4, BigQuery, Salesforce Marketing Cloud, HubSpot, A/B testing, Cohort Analysis, CAC, LTV, Churn, PLG">
   <title>Currículo de Peter Mac Hamilton</title>
   <link rel="stylesheet" href="style.css">
+  <style>
+    .tabs {
+      display: flex;
+      gap: 0.5rem;
+      margin-top: 1rem;
+    }
+    .tab-button {
+      padding: 0.5rem 1rem;
+      cursor: pointer;
+    }
+    #cv.v2 {
+      font-family: 'Times New Roman', serif;
+    }
+    #cv.v3 {
+      font-size: 0.9rem;
+    }
+    #cv.v4 {
+      background-color: #f0f0f0;
+      border: 2px dashed #333;
+      padding: 1rem;
+    }
+  </style>
 </head>
 <body class="cv-page">
-  <div class="container">
+  <div id="cv" class="container v1">
     <!-- Dados Pessoais -->
     <header>
       <h1>Peter Mac Hamilton</h1>
@@ -105,5 +127,20 @@
       <p><strong>Espanhol:</strong> Intermediário</p>
     </section>
   </div>
-</body>
-</html>
+  <nav class="tabs">
+    <button class="tab-button" data-target="v1">Moderna</button>
+    <button class="tab-button" data-target="v2">Clássica</button>
+    <button class="tab-button" data-target="v3">Compacta</button>
+    <button class="tab-button" data-target="v4">Criativa</button>
+  </nav>
+  <script>
+    const buttons = document.querySelectorAll('.tab-button');
+    const cv = document.getElementById('cv');
+    buttons.forEach(btn => {
+      btn.addEventListener('click', () => {
+        cv.className = 'container ' + btn.dataset.target;
+      });
+    });
+  </script>
+  </body>
+  </html>


### PR DESCRIPTION
## Summary
- rename `cv-modern.html` to `SeniorProductManager.html`
- add four tab buttons (Moderna, Clássica, Compacta, Criativa) with JavaScript to switch styles

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68b9a04c6530832eb01852d60134f316