### PR TITLE
Add tabbed Senior Product Manager resume

### DIFF
--- a/SeniorProductManager.html
+++ b/SeniorProductManager.html
@@ -1,0 +1,51 @@
+<!DOCTYPE html>
+<html lang="pt-BR" class="cv-page">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>Senior Product Manager - Versões</title>
+    <link rel="stylesheet" href="style.css">
+</head>
+<body>
+    <div class="container">
+        <nav class="tab-nav">
+            <ul>
+                <li><a href="#modern" class="active">Moderna</a></li>
+                <li><a href="#classic">Clássica</a></li>
+                <li><a href="#minimal">Minimalista</a></li>
+                <li><a href="#creative">Criativa</a></li>
+            </ul>
+        </nav>
+        <section id="modern" class="tab-section active">
+            <h2>Versão Moderna</h2>
+            <p>Conteúdo da versão moderna do currículo.</p>
+        </section>
+        <section id="classic" class="tab-section">
+            <h2>Versão Clássica</h2>
+            <p>Conteúdo da versão clássica do currículo.</p>
+        </section>
+        <section id="minimal" class="tab-section">
+            <h2>Versão Minimalista</h2>
+            <p>Conteúdo da versão minimalista do currículo.</p>
+        </section>
+        <section id="creative" class="tab-section">
+            <h2>Versão Criativa</h2>
+            <p>Conteúdo da versão criativa do currículo.</p>
+        </section>
+    </div>
+    <script>
+        const tabs = document.querySelectorAll('.tab-nav a');
+        const sections = document.querySelectorAll('.tab-section');
+        tabs.forEach(tab => {
+            tab.addEventListener('click', event => {
+                event.preventDefault();
+                const target = tab.getAttribute('href').substring(1);
+                sections.forEach(sec => sec.classList.remove('active'));
+                document.getElementById(target).classList.add('active');
+                tabs.forEach(t => t.classList.remove('active'));
+                tab.classList.add('active');
+            });
+        });
+    </script>
+</body>
+</html>

--- a/style.css
+++ b/style.css
@@ -111,3 +111,35 @@
         break-inside: avoid;
     }
 }
+
+/* Tab navigation styles */
+.cv-page .tab-nav ul {
+    display: flex;
+    list-style: none;
+    margin-bottom: 20px;
+    padding-left: 0;
+}
+
+.cv-page .tab-nav li {
+    margin-right: 10px;
+}
+
+.cv-page .tab-nav a {
+    display: block;
+    padding: 8px 12px;
+    background-color: #eee;
+    border-radius: 4px;
+}
+
+.cv-page .tab-nav a.active {
+    background-color: #3498db;
+    color: #fff;
+}
+
+.cv-page .tab-section {
+    display: none;
+}
+
+.cv-page .tab-section.active {
+    display: block;
+}


### PR DESCRIPTION
## Summary
- add Senior Product Manager resume page with four tabbed versions
- style and script tabs to display only active version

## Testing
- `node -e "const fs=require('fs');const html=fs.readFileSync('SeniorProductManager.html','utf8');const sections=(html.match(/class=\\\"tab-section/g)||[]).length;const active=(html.match(/tab-section active/g)||[]).length;console.log('sections',sections);console.log('active sections',active);"`
- `npm install jsdom --no-save` (fails: 403 Forbidden)


------
https://chatgpt.com/codex/tasks/task_e_68b9a235b434832ebee8d32680f4c8bc