### PR TITLE
Add multilingual CV with improved styling

### DIFF
--- a/SeniorProductManager-en.html
+++ b/SeniorProductManager-en.html
@@ -1,0 +1,142 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <meta name="keywords" content="Senior Product Manager, Digital Products, Strategy, Discovery, Delivery, Experiments, A/B Testing, Product Metrics, OKRs, UX, Data">
+  <title>Peter Mac Hamilton Resume</title>
+  <link id="style-link" rel="stylesheet" href="style.css">
+  <style>
+    .tabs {
+      display: flex;
+      gap: 0.5rem;
+      margin-top: 1rem;
+    }
+    .tab-button {
+      padding: 0.5rem 1rem;
+      cursor: pointer;
+    }
+  </style>
+</head>
+<body class="cv-page">
+  <div id="cv" class="container">
+      <nav class="lang-switch"><a href="SeniorProductManager.html">PT</a> | <a href="SeniorProductManager-en.html" class="current">EN</a> | <a href="SeniorProductManager-es.html">ES</a></nav>
+    <!-- Personal Data -->
+    <header>
+      <h1>Peter Mac Hamilton</h1>
+      <p><strong>Senior PM | Digital Products | Discovery, Strategy & Delivery | Data-informed</strong></p>
+      <p>São Paulo, Brazil | +55 11 96953-4105 | <a href="mailto:novoemaildopeter@gmail.com">novoemaildopeter@gmail.com</a> | <a href="https://www.linkedin.com/in/peter-mac-hamilton" target="_blank">linkedin.com/in/peter-mac-hamilton/</a></p>
+    </header>
+
+    <!-- Summary -->
+    <section id="summary">
+      <h2>Summary</h2>
+      <p>Senior PM for digital products. I work from discovery to delivery, connecting strategy, UX and data. I treat growth as a capability, not an end: clear hypotheses, tests and funnel optimization for measurable impact, focusing on product impact and user experience.</p>
+    </section>
+
+    <!-- Key Impact -->
+    <section>
+      <h2>Key Impact in 3 bullets</h2>
+      <ul>
+        <li>−70% time to first value and −50% support tickets (guided onboarding + knowledge base).</li>
+        <li>10k+ students in EdTech with subscription model (acquisition → conversion → retention).</li>
+        <li>200% growth in prescriptions with loyalty and retention program.</li>
+      </ul>
+    </section>
+
+    <!-- Professional Experience -->
+    <section>
+      <h2>Professional Experience</h2>
+
+      <div class="job">
+        <h3>PremieRpet — Senior Product Manager (Nov/2024 – present) · São Paulo · Digital Product</h3>
+        <ul>
+          <li>Defined clear success metrics (north star and activation/engagement indicators).</li>
+          <li>Instrumented user journey and built backlog of low-friction improvements and experiments.</li>
+          <li>Worked with UX, data, marketing and engineering to prioritize by impact.</li>
+          <li>Integrated CRM and marketing automation for lifecycle and end-to-end measurement.</li>
+        </ul>
+      </div>
+
+      <div class="job">
+        <h3>Gedanken (GCertifica) — Product Manager (May/2022 – Nov/2024) · São Paulo · B2B SaaS</h3>
+        <ul>
+          <li>Redesigned onboarding and standardized deliverables; knowledge base and self-service.</li>
+          <li>Continuous funnel experiments (copy/CTA/flow) and cohort analyses.</li>
+          <li><strong>Results</strong>: <strong>−70% TTFV</strong>, <strong>−50% tickets</strong>, improved <strong>retention</strong> and <strong>NPS</strong>.</li>
+        </ul>
+      </div>
+
+      <div class="job">
+        <h3>Se Liga (EdTech) — Product Manager (Jul/2017 – May/2022) · B2C subscription</h3>
+        <ul>
+          <li>Migrated from free content to <strong>subscription model</strong>; built the <strong>LMS</strong>.</li>
+          <li>Optimized <strong>landing pages</strong> and conversion flow; usage rituals for <strong>retention</strong>.</li>
+          <li><strong>Results</strong>: <strong>10k+ students</strong> with a sustainable operation.</li>
+        </ul>
+      </div>
+    </section>
+
+    <!-- Education -->
+    <section>
+      <h2>Education</h2>
+      <ul>
+        <li><strong>Postgraduate in Leadership and People Management</strong>, Descomplica (Dec 2023)</li>
+        <li><strong>Postgraduate in Product Management</strong>, Descomplica (Dec 2022)</li>
+        <li><strong>MBA in Strategic Project Management and Agile Methodologies</strong>, Descomplica (Jul 2022)</li>
+        <li><strong>Bachelor in Advertising</strong>, Belas Artes (Dec 2009)</li>
+        <li><strong>Technical High School in Information Technology</strong>, ETEC Camargo Aranha (Dec 2004)</li>
+      </ul>
+    </section>
+
+    <!-- Skills -->
+    <section>
+      <h2>Skills & Tools (stack-agnostic)</h2>
+      <ul>
+        <li><strong>Product</strong>: discovery, roadmap, impact-based prioritization (ICE/PIE), OKRs, squad operations.</li>
+        <li><strong>Metrics</strong>: acquisition, activation, engagement, retention; time to value; satisfaction (NPS).</li>
+        <li><strong>Experiments</strong>: lightweight A/B tests, simple hypotheses, fast learning.</li>
+        <li><strong>Data & Martech</strong>: experience with GA4/BigQuery, Amplitude/Segment, HubSpot/RD, CRM/automation — I adapt to the team's stack.</li>
+        <li><strong>UX & Operations</strong>: Figma, Miro, Jira; support and knowledge base (Zendesk).</li>
+      </ul>
+    </section>
+
+    <section>
+      <h2>Certifications</h2>
+      <ul>
+        <li>CSPO — K21</li>
+        <li>Digital Product Leadership — TERA</li>
+        <li>Artificial Intelligence in Digital Business — TERA</li>
+      </ul>
+    </section>
+
+    <!-- Languages -->
+    <section>
+      <h2>Languages</h2>
+      <p><strong>English:</strong> Advanced</p>
+      <p><strong>Spanish:</strong> Intermediate</p>
+    </section>
+  </div>
+
+  <nav class="tabs">
+    <button class="tab-button" data-style="1">Modern</button>
+    <button class="tab-button" data-style="2">Classic</button>
+    <button class="tab-button" data-style="3">Compact</button>
+    <button class="tab-button" data-style="4">Creative</button>
+  </nav>
+
+  <script>
+    const styleLink = document.getElementById('style-link');
+    document.querySelectorAll('.tab-button').forEach(btn => {
+      btn.addEventListener('click', () => {
+        styleLink.href = `style_${btn.dataset.style}.css`;
+      });
+    });
+    document.addEventListener('keydown', e => {
+      if (['1', '2', '3', '4'].includes(e.key)) {
+        styleLink.href = `style_${e.key}.css`;
+      }
+    });
+  </script>
+</body>
+</html>

--- a/SeniorProductManager-es.html
+++ b/SeniorProductManager-es.html
@@ -1,0 +1,142 @@
+<!DOCTYPE html>
+<html lang="es">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <meta name="keywords" content="Product Manager Senior, Productos Digitales, Estrategia, Discovery, Entrega, Experimentos, A/B Testing, Métricas de Producto, OKRs, UX, Datos">
+  <title>Currículum de Peter Mac Hamilton</title>
+  <link id="style-link" rel="stylesheet" href="style.css">
+  <style>
+    .tabs {
+      display: flex;
+      gap: 0.5rem;
+      margin-top: 1rem;
+    }
+    .tab-button {
+      padding: 0.5rem 1rem;
+      cursor: pointer;
+    }
+  </style>
+</head>
+<body class="cv-page">
+  <div id="cv" class="container">
+      <nav class="lang-switch"><a href="SeniorProductManager.html">PT</a> | <a href="SeniorProductManager-en.html">EN</a> | <a href="SeniorProductManager-es.html" class="current">ES</a></nav>
+    <!-- Datos Personales -->
+    <header>
+      <h1>Peter Mac Hamilton</h1>
+      <p><strong>PM Senior | Productos Digitales | Discovery, Estrategia y Entrega | Orientado a datos</strong></p>
+      <p>São Paulo, Brasil | +55 11 96953-4105 | <a href="mailto:novoemaildopeter@gmail.com">novoemaildopeter@gmail.com</a> | <a href="https://www.linkedin.com/in/peter-mac-hamilton" target="_blank">linkedin.com/in/peter-mac-hamilton/</a></p>
+    </header>
+
+    <!-- Resumen -->
+    <section id="summary">
+      <h2>Resumen</h2>
+      <p>PM Senior de productos digitales. Actúo desde el discovery hasta la entrega, uniendo estrategia, UX y datos. Trato el growth como una capacidad, no como un fin: hipótesis claras, pruebas y optimización del embudo para impacto medible, enfocándome en el impacto del producto y la experiencia del usuario.</p>
+    </section>
+
+    <!-- Impacto -->
+    <section>
+      <h2>Impacto en 3 puntos</h2>
+      <ul>
+        <li>−70% en el tiempo hasta el primer valor y −50% en tickets (onboarding guiado + base de conocimiento).</li>
+        <li>10k+ alumnos en EdTech con modelo de suscripción (adquisición → conversión → retención).</li>
+        <li>Crecimiento del 200% en prescripciones con programa de fidelización y retención.</li>
+      </ul>
+    </section>
+
+    <!-- Experiencia Profesional -->
+    <section>
+      <h2>Experiencia Profesional</h2>
+
+      <div class="job">
+        <h3>PremieRpet — Senior Product Manager (nov/2024 – presente) · São Paulo · Producto Digital</h3>
+        <ul>
+          <li>Definí métricas de éxito claras (métrica norte e indicadores de activación y engagement).</li>
+          <li>Instrumenté la jornada del usuario y creé un backlog de mejoras y experimentos de bajo roce.</li>
+          <li>Trabajo integrado con UX, datos, marketing e ingeniería para priorizar por impacto.</li>
+          <li>Integraciones con CRM y automatización de marketing para lifecycle y medición punta a punta.</li>
+        </ul>
+      </div>
+
+      <div class="job">
+        <h3>Gedanken (GCertifica) — Product Manager (may/2022 – nov/2024) · São Paulo · B2B SaaS</h3>
+        <ul>
+          <li>Rediseño de <strong>onboarding</strong> y estandarización de entregas; <strong>base de conocimiento</strong> y autoservicio.</li>
+          <li>Experimentos continuos en el embudo (texto/CTA/flujo) y análisis por grupos de usuarios.</li>
+          <li><strong>Resultados</strong>: <strong>−70% TTFV</strong>, <strong>−50% tickets</strong>, mejora de <strong>retención</strong> y <strong>NPS</strong>.</li>
+        </ul>
+      </div>
+
+      <div class="job">
+        <h3>Se Liga (EdTech) — Product Manager (jul/2017 – may/2022) · B2C suscripción</h3>
+        <ul>
+          <li>Migración de contenido abierto a <strong>modelo de suscripción</strong>; construcción del <strong>LMS</strong>.</li>
+          <li>Optimización de <strong>landing pages</strong> y flujo de conversión; rituales de uso para <strong>retención</strong>.</li>
+          <li><strong>Resultados</strong>: <strong>10k+ alumnos</strong> con operación sostenible.</li>
+        </ul>
+      </div>
+    </section>
+
+    <!-- Formación Académica -->
+    <section>
+      <h2>Formación Académica</h2>
+      <ul>
+        <li><strong>Posgrado en Liderazgo y Gestión de Personas</strong>, Descomplica (diciembre de 2023)</li>
+        <li><strong>Posgrado en Gestión de Productos</strong>, Descomplica (diciembre de 2022)</li>
+        <li><strong>MBA en Gestión Estratégica de Proyectos y Metodologías Ágiles</strong>, Descomplica (julio de 2022)</li>
+        <li><strong>Licenciatura en Publicidad</strong>, Belas Artes (diciembre de 2009)</li>
+        <li><strong>Bachillerato Técnico en Tecnología de la Información</strong>, ETEC Camargo Aranha (diciembre de 2004)</li>
+      </ul>
+    </section>
+
+    <!-- Competencias -->
+    <section>
+      <h2>Competencias y Herramientas (agnóstico de stack)</h2>
+      <ul>
+        <li><strong>Producto</strong>: discovery, roadmap, priorización por impacto (ICE/PIE), OKRs, operación de squads.</li>
+        <li><strong>Métricas</strong>: adquisición, activación, engagement, retención; tiempo hasta valor; satisfacción (NPS).</li>
+        <li><strong>Experimentos</strong>: pruebas A/B ligeras, hipótesis simples, aprendizaje rápido.</li>
+        <li><strong>Datos y Martech</strong>: experiencia con GA4/BigQuery, Amplitude/Segment, HubSpot/RD, CRM/automatización — me adapto al stack del equipo.</li>
+        <li><strong>UX y Operaciones</strong>: Figma, Miro, Jira; soporte y base de conocimiento (Zendesk).</li>
+      </ul>
+    </section>
+
+    <section>
+      <h2>Certificaciones</h2>
+      <ul>
+        <li>CSPO — K21</li>
+        <li>Digital Product Leadership — TERA</li>
+        <li>Inteligencia Artificial en Negocios Digitales — TERA</li>
+      </ul>
+    </section>
+
+    <!-- Idiomas -->
+    <section>
+      <h2>Idiomas</h2>
+      <p><strong>Inglés:</strong> Avanzado</p>
+      <p><strong>Español:</strong> Intermedio</p>
+    </section>
+  </div>
+
+  <nav class="tabs">
+    <button class="tab-button" data-style="1">Moderna</button>
+    <button class="tab-button" data-style="2">Clásica</button>
+    <button class="tab-button" data-style="3">Compacta</button>
+    <button class="tab-button" data-style="4">Creativa</button>
+  </nav>
+
+  <script>
+    const styleLink = document.getElementById('style-link');
+    document.querySelectorAll('.tab-button').forEach(btn => {
+      btn.addEventListener('click', () => {
+        styleLink.href = `style_${btn.dataset.style}.css`;
+      });
+    });
+    document.addEventListener('keydown', e => {
+      if (['1', '2', '3', '4'].includes(e.key)) {
+        styleLink.href = `style_${e.key}.css`;
+      }
+    });
+  </script>
+</body>
+</html>

--- a/SeniorProductManager.html
+++ b/SeniorProductManager.html
@@ -21,6 +21,7 @@
 </head>
 <body class="cv-page">
   <div id="cv" class="container">
+      <nav class="lang-switch"><a href="SeniorProductManager.html" class="current">PT</a> | <a href="SeniorProductManager-en.html">EN</a> | <a href="SeniorProductManager-es.html">ES</a></nav>
     <!-- Dados Pessoais -->
     <header>
       <h1>Peter Mac Hamilton</h1>

--- a/style.css
+++ b/style.css
@@ -1,145 +1,138 @@
-.cv-page * {
-    margin: 0;
-    padding: 0;
-    box-sizing: border-box;
+:root {
+  --primary: #1D3557;
+  --accent: #E63946;
+  --bg: #F1FAEE;
+  --card: #ffffff;
+  --muted: #555;
 }
 
-.cv-page body {
-    font-family: Arial, sans-serif;
-    background-color: #f4f4f4;
-    color: #333;
-    line-height: 1.6;
+* {
+  margin: 0;
+  padding: 0;
+  box-sizing: border-box;
+}
+
+body.cv-page {
+  font-family: Arial, sans-serif;
+  background: var(--bg);
+  color: var(--primary);
+  line-height: 1.6;
 }
 
 .cv-page .container {
-    width: 80%;
-    margin: 20px auto;
-    padding: 20px;
-    background-color: #fff;
-    border-radius: 8px;
-    box-shadow: 0 0 10px rgba(0, 0, 0, 0.1);
+  max-width: 800px;
+  margin: 2rem auto;
+  padding: 2rem;
+  background: var(--card);
+  border-radius: 8px;
+  box-shadow: 0 0 10px rgba(0,0,0,0.05);
+  position: relative;
 }
 
-.cv-page header {
-    text-align: center;
-    margin-bottom: 20px;
+.lang-switch {
+  position: absolute;
+  top: 1rem;
+  right: 1rem;
+  font-size: 0.9rem;
+}
+.lang-switch a {
+  color: var(--accent);
+  margin-left: 0.5rem;
+  text-decoration: none;
+}
+.lang-switch a.current {
+  font-weight: bold;
+  text-decoration: underline;
 }
 
-.cv-page header h1 {
-    font-size: 2em;
-    color: #2c3e50;
+header {
+  text-align: center;
+  margin-bottom: 2rem;
+}
+header h1 {
+  color: var(--accent);
+  font-size: 2.2rem;
+}
+header p {
+  margin-top: 0.5rem;
 }
 
-.cv-page header p {
-    margin-top: 5px;
-    font-size: 1em;
+a {
+  color: var(--accent);
+  text-decoration: none;
+}
+a:hover {
+  text-decoration: underline;
 }
 
-.cv-page a {
-    color: #3498db;
-    text-decoration: none;
+section {
+  margin-bottom: 1.5rem;
+  padding-left: 1rem;
+  border-left: 4px solid var(--accent);
+}
+section h2 {
+  font-size: 1.4rem;
+  color: var(--accent);
+  margin-bottom: 0.5rem;
+}
+section p {
+  text-align: justify;
 }
 
-.cv-page a:hover {
-    text-decoration: underline;
+.job h3 {
+  font-size: 1.2rem;
+  color: var(--primary);
+}
+.job p {
+  font-style: italic;
+  color: var(--muted);
 }
 
-.cv-page section {
-    margin-bottom: 20px;
+ul {
+  list-style: disc;
+  margin-left: 1.5rem;
+}
+ul li {
+  margin-bottom: 0.5rem;
 }
 
-.cv-page section p {
-    text-align: justify;
+.tabs {
+  display: flex;
+  gap: 0.5rem;
+  justify-content: center;
+  margin: 1rem 0;
+}
+.tab-button {
+  padding: 0.4rem 0.8rem;
+  border: 1px solid var(--accent);
+  border-radius: 4px;
+  background: var(--card);
+  color: var(--accent);
+  cursor: pointer;
+  font: inherit;
+}
+.tab-button:hover {
+  background: var(--accent);
+  color: var(--card);
 }
 
-.cv-page section h2 {
-    font-size: 1.5em;
-    border-bottom: 2px solid #3498db;
-    padding-bottom: 5px;
-    margin-bottom: 10px;
-    color: #2c3e50;
-}
-
-.cv-page .job h3 {
-    font-size: 1.2em;
-    color: #2980b9;
-}
-
-.cv-page .job p {
-    font-style: italic;
-    color: #7f8c8d;
-}
-
-.cv-page ul {
-    list-style-type: disc;
-    margin-left: 20px;
-}
-
-.cv-page ul li {
-    margin-bottom: 10px;
-}
-
-/* Estilos específicos para impressão */
 @media print {
-    .cv-page body {
-        background-color: white;
-        color: black;
-    }
-
-    .cv-page .container {
-        width: 100%;
-        margin: 0;
-        padding: 0;
-        border: none;
-        box-shadow: none;
-    }
-
-    .cv-page a {
-        color: black;
-        text-decoration: none;
-    }
-
-    .cv-page header {
-        text-align: left;
-    }
-
-    .cv-page section {
-        page-break-inside: avoid;
-    }
-
-    .cv-page h1, .cv-page h2, .cv-page h3 {
-        break-inside: avoid;
-    }
-}
-
-/* Tab navigation styles */
-.cv-page .tab-nav ul {
-    display: flex;
-    list-style: none;
-    margin-bottom: 20px;
+  body.cv-page {
+    background: #fff;
+    color: #000;
+  }
+  .cv-page .container {
+    box-shadow: none;
+    border: none;
+    margin: 0;
+    padding: 0;
+  }
+  a {
+    color: #000;
+    text-decoration: none;
+  }
+  section {
+    border-left: none;
     padding-left: 0;
-}
-
-.cv-page .tab-nav li {
-    margin-right: 10px;
-}
-
-.cv-page .tab-nav a {
-    display: block;
-    padding: 8px 12px;
-    background-color: #eee;
-    border-radius: 4px;
-}
-
-.cv-page .tab-nav a.active {
-    background-color: #3498db;
-    color: #fff;
-}
-
-.cv-page .tab-section {
-    display: none;
-}
-
-.cv-page .tab-section.active {
-    display: block;
+  }
 }

--- a/style_1.css
+++ b/style_1.css
@@ -2,12 +2,12 @@
 /* ========= base & tokens ========= */
 :root {
   --font-sans: Inter, ui-sans-serif, system-ui, -apple-system, Segoe UI, Roboto, Helvetica, Arial, "Apple Color Emoji", "Segoe UI Emoji";
-  --bg: #f7f7f8;
+  --bg: #F1FAEE;
   --card: #ffffff;
-  --text: #0f172a;      /* slate-900 */
-  --muted: #475569;     /* slate-600 */
+  --text: #1D3557;      /* navy */
+  --muted: #555;        /* muted */
   --line: #e5e7eb;      /* gray-200 */
-  --accent: #2563eb;    /* blue-600 */
+  --accent: #E63946;    /* red */
   --radius: 14px;
   --shadow: 0 1px 2px rgba(0,0,0,.04), 0 8px 24px rgba(0,0,0,.08);
 
@@ -41,6 +41,23 @@ body.cv-page {
   border-radius: var(--radius);
   box-shadow: var(--shadow);
   border: 1px solid var(--line);
+  position: relative;
+}
+
+.lang-switch {
+  position: absolute;
+  top: 1rem;
+  right: 1rem;
+  font-size: 0.9rem;
+}
+.lang-switch a {
+  color: var(--accent);
+  margin-left: 0.5rem;
+  text-decoration: none;
+}
+.lang-switch a.current {
+  font-weight: 700;
+  text-decoration: underline;
 }
 
 /* ========= header ========= */
@@ -53,7 +70,7 @@ body.cv-page {
   font-size: clamp(1.9rem, 3.5vw, 2.4rem);
   font-weight: 800;
   letter-spacing: 0.2px;
-  color: var(--text);
+  color: var(--accent);
   margin-bottom: .25rem;
 }
 
@@ -72,14 +89,18 @@ body.cv-page {
 .cv-page a:hover { text-decoration: underline; }
 
 /* ========= seções ========= */
-.cv-page section { margin-bottom: var(--space-5); }
+.cv-page section {
+  margin-bottom: var(--space-5);
+  padding-left: 1rem;
+  border-left: 4px solid var(--accent);
+}
 
 .cv-page section h2 {
   font-size: clamp(1.00rem, 2.2vw, 1.15rem);
   font-weight: 700;
-  color: var(--text);
+  color: var(--accent);
   padding-bottom: .4rem;
-  border-bottom: 1px solid var(--line);
+  border-bottom: 1px solid var(--accent);
   margin-bottom: var(--space-3);
   letter-spacing: .2px;
 }
@@ -130,16 +151,17 @@ body.cv-page {
 
 .cv-page .tab-button {
   padding: .45rem .9rem;
-  border: 1px solid var(--line);
+  border: 1px solid var(--accent);
   border-radius: 999px;
   background: #fff;
+  color: var(--accent);
   cursor: pointer;
   font: inherit;
 }
 
 .cv-page .tab-button:hover {
-  border-color: var(--accent);
-  color: var(--accent);
+  background: var(--accent);
+  color: #fff;
 }
 
 /* ========= print ========= */

--- a/style_2.css
+++ b/style_2.css
@@ -2,12 +2,12 @@
 /* ========= base & tokens ========= */
 :root {
   --font-sans: 'Times New Roman', serif;
-  --bg: #f7f7f8;
+  --bg: #F1FAEE;
   --card: #ffffff;
-  --text: #0f172a;      /* slate-900 */
-  --muted: #475569;     /* slate-600 */
+  --text: #1D3557;      /* navy */
+  --muted: #555;        /* muted */
   --line: #e5e7eb;      /* gray-200 */
-  --accent: #2563eb;    /* blue-600 */
+  --accent: #E63946;    /* red */
   --radius: 14px;
   --shadow: 0 1px 2px rgba(0,0,0,.04), 0 8px 24px rgba(0,0,0,.08);
 
@@ -41,6 +41,23 @@ body.cv-page {
   border-radius: var(--radius);
   box-shadow: var(--shadow);
   border: 1px solid var(--line);
+  position: relative;
+}
+
+.lang-switch {
+  position: absolute;
+  top: 1rem;
+  right: 1rem;
+  font-size: 0.9rem;
+}
+.lang-switch a {
+  color: var(--accent);
+  margin-left: 0.5rem;
+  text-decoration: none;
+}
+.lang-switch a.current {
+  font-weight: 700;
+  text-decoration: underline;
 }
 
 /* ========= header ========= */
@@ -53,7 +70,7 @@ body.cv-page {
   font-size: clamp(1.9rem, 3.5vw, 2.4rem);
   font-weight: 800;
   letter-spacing: 0.2px;
-  color: var(--text);
+  color: var(--accent);
   margin-bottom: .25rem;
 }
 
@@ -72,14 +89,18 @@ body.cv-page {
 .cv-page a:hover { text-decoration: underline; }
 
 /* ========= seções ========= */
-.cv-page section { margin-bottom: var(--space-5); }
+.cv-page section {
+  margin-bottom: var(--space-5);
+  padding-left: 1rem;
+  border-left: 4px solid var(--accent);
+}
 
 .cv-page section h2 {
   font-size: clamp(1.00rem, 2.2vw, 1.15rem);
   font-weight: 700;
-  color: var(--text);
+  color: var(--accent);
   padding-bottom: .4rem;
-  border-bottom: 1px solid var(--line);
+  border-bottom: 1px solid var(--accent);
   margin-bottom: var(--space-3);
   letter-spacing: .2px;
 }
@@ -130,16 +151,17 @@ body.cv-page {
 
 .cv-page .tab-button {
   padding: .45rem .9rem;
-  border: 1px solid var(--line);
+  border: 1px solid var(--accent);
   border-radius: 999px;
   background: #fff;
+  color: var(--accent);
   cursor: pointer;
   font: inherit;
 }
 
 .cv-page .tab-button:hover {
-  border-color: var(--accent);
-  color: var(--accent);
+  background: var(--accent);
+  color: #fff;
 }
 
 /* ========= print ========= */

--- a/style_3.css
+++ b/style_3.css
@@ -2,12 +2,12 @@
 /* ========= base & tokens ========= */
 :root {
   --font-sans: Inter, ui-sans-serif, system-ui, -apple-system, Segoe UI, Roboto, Helvetica, Arial, "Apple Color Emoji", "Segoe UI Emoji";
-  --bg: #f7f7f8;
+  --bg: #F1FAEE;
   --card: #ffffff;
-  --text: #0f172a;      /* slate-900 */
-  --muted: #475569;     /* slate-600 */
+  --text: #1D3557;      /* navy */
+  --muted: #555;        /* muted */
   --line: #e5e7eb;      /* gray-200 */
-  --accent: #2563eb;    /* blue-600 */
+  --accent: #E63946;    /* red */
   --radius: 14px;
   --shadow: 0 1px 2px rgba(0,0,0,.04), 0 8px 24px rgba(0,0,0,.08);
 
@@ -42,6 +42,23 @@ body.cv-page {
   border-radius: var(--radius);
   box-shadow: var(--shadow);
   border: 1px solid var(--line);
+  position: relative;
+}
+
+.lang-switch {
+  position: absolute;
+  top: 1rem;
+  right: 1rem;
+  font-size: 0.9rem;
+}
+.lang-switch a {
+  color: var(--accent);
+  margin-left: 0.5rem;
+  text-decoration: none;
+}
+.lang-switch a.current {
+  font-weight: 700;
+  text-decoration: underline;
 }
 
 /* ========= header ========= */
@@ -54,7 +71,7 @@ body.cv-page {
   font-size: clamp(1.9rem, 3.5vw, 2.4rem);
   font-weight: 800;
   letter-spacing: 0.2px;
-  color: var(--text);
+  color: var(--accent);
   margin-bottom: .25rem;
 }
 
@@ -73,14 +90,18 @@ body.cv-page {
 .cv-page a:hover { text-decoration: underline; }
 
 /* ========= seções ========= */
-.cv-page section { margin-bottom: var(--space-5); }
+.cv-page section {
+  margin-bottom: var(--space-5);
+  padding-left: 1rem;
+  border-left: 4px solid var(--accent);
+}
 
 .cv-page section h2 {
   font-size: clamp(1.00rem, 2.2vw, 1.15rem);
   font-weight: 700;
-  color: var(--text);
+  color: var(--accent);
   padding-bottom: .4rem;
-  border-bottom: 1px solid var(--line);
+  border-bottom: 1px solid var(--accent);
   margin-bottom: var(--space-3);
   letter-spacing: .2px;
 }
@@ -131,16 +152,17 @@ body.cv-page {
 
 .cv-page .tab-button {
   padding: .45rem .9rem;
-  border: 1px solid var(--line);
+  border: 1px solid var(--accent);
   border-radius: 999px;
   background: #fff;
+  color: var(--accent);
   cursor: pointer;
   font: inherit;
 }
 
 .cv-page .tab-button:hover {
-  border-color: var(--accent);
-  color: var(--accent);
+  background: var(--accent);
+  color: #fff;
 }
 
 /* ========= print ========= */

--- a/style_4.css
+++ b/style_4.css
@@ -2,12 +2,12 @@
 /* ========= base & tokens ========= */
 :root {
   --font-sans: Inter, ui-sans-serif, system-ui, -apple-system, Segoe UI, Roboto, Helvetica, Arial, "Apple Color Emoji", "Segoe UI Emoji";
-  --bg: #f7f7f8;
+  --bg: #F1FAEE;
   --card: #ffffff;
-  --text: #0f172a;      /* slate-900 */
-  --muted: #475569;     /* slate-600 */
+  --text: #1D3557;      /* navy */
+  --muted: #555;        /* muted */
   --line: #e5e7eb;      /* gray-200 */
-  --accent: #2563eb;    /* blue-600 */
+  --accent: #E63946;    /* red */
   --radius: 14px;
   --shadow: 0 1px 2px rgba(0,0,0,.04), 0 8px 24px rgba(0,0,0,.08);
 
@@ -37,10 +37,27 @@ body.cv-page {
   max-width: 820px;
   margin: var(--space-6) auto;
   padding: 1rem;
-  background: #f0f0f0;
+  background: var(--card);
   border-radius: var(--radius);
   box-shadow: var(--shadow);
-  border: 2px dashed #333;
+  border: 2px dashed var(--accent);
+  position: relative;
+}
+
+.lang-switch {
+  position: absolute;
+  top: 1rem;
+  right: 1rem;
+  font-size: 0.9rem;
+}
+.lang-switch a {
+  color: var(--accent);
+  margin-left: 0.5rem;
+  text-decoration: none;
+}
+.lang-switch a.current {
+  font-weight: 700;
+  text-decoration: underline;
 }
 
 /* ========= header ========= */
@@ -53,7 +70,7 @@ body.cv-page {
   font-size: clamp(1.9rem, 3.5vw, 2.4rem);
   font-weight: 800;
   letter-spacing: 0.2px;
-  color: var(--text);
+  color: var(--accent);
   margin-bottom: .25rem;
 }
 
@@ -72,14 +89,18 @@ body.cv-page {
 .cv-page a:hover { text-decoration: underline; }
 
 /* ========= seções ========= */
-.cv-page section { margin-bottom: var(--space-5); }
+.cv-page section {
+  margin-bottom: var(--space-5);
+  padding-left: 1rem;
+  border-left: 4px solid var(--accent);
+}
 
 .cv-page section h2 {
   font-size: clamp(1.00rem, 2.2vw, 1.15rem);
   font-weight: 700;
-  color: var(--text);
+  color: var(--accent);
   padding-bottom: .4rem;
-  border-bottom: 1px solid var(--line);
+  border-bottom: 1px solid var(--accent);
   margin-bottom: var(--space-3);
   letter-spacing: .2px;
 }
@@ -130,16 +151,17 @@ body.cv-page {
 
 .cv-page .tab-button {
   padding: .45rem .9rem;
-  border: 1px solid var(--line);
+  border: 1px solid var(--accent);
   border-radius: 999px;
   background: #fff;
+  color: var(--accent);
   cursor: pointer;
   font: inherit;
 }
 
 .cv-page .tab-button:hover {
-  border-color: var(--accent);
-  color: var(--accent);
+  background: var(--accent);
+  color: #fff;
 }
 
 /* ========= print ========= */


### PR DESCRIPTION
## Summary
- add English and Spanish CV pages with a subtle language switch
- refresh all styles with a two-color palette and clearer section layout

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68bb20089e98832e84b36039383e143e