### PR TITLE
feat: add alternate CV templates

### DIFF
--- a/SeniorProductManager_v1.html
+++ b/SeniorProductManager_v1.html
@@ -1,0 +1,86 @@
+<!DOCTYPE html>
+<html lang="pt-BR">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>Peter Mac Hamilton - CV v1</title>
+  <link rel="stylesheet" href="style_v1.css">
+</head>
+<body class="cv">
+  <header class="hero">
+    <h1>Peter Mac Hamilton</h1>
+    <p class="tagline">PM Sênior | Produtos Digitais | Data-informed</p>
+    <p class="contact">São Paulo, SP · 11 96953-4105 · <a href="mailto:novoemaildopeter@gmail.com">novoemaildopeter@gmail.com</a></p>
+    <p class="links"><a href="https://www.linkedin.com/in/peter-mac-hamilton" target="_blank">linkedin.com/in/peter-mac-hamilton</a></p>
+  </header>
+  <main>
+    <section id="summary">
+      <h2>Resumo</h2>
+      <p>PM Sênior em produtos digitais. Atuo do discovery à entrega, unindo estratégia, UX e dados. Trato growth como capacidade, não fim: hipóteses claras, testes e otimização do funil para impacto mensurável.</p>
+    </section>
+    <section id="experience">
+      <h2>Experiência</h2>
+      <article class="job">
+        <h3>PremieRpet — Senior Product Manager</h3>
+        <span class="meta">nov/2024 – presente · São Paulo</span>
+        <ul>
+          <li>Defini métricas de sucesso claras (métrica norte e indicadores de ativação e engajamento).</li>
+          <li>Instrumentei a jornada do usuário e criei backlog de melhorias e experimentos de baixo atrito.</li>
+          <li>Integrações com CRM e automação de marketing para lifecycle e mensuração ponta a ponta.</li>
+        </ul>
+      </article>
+      <article class="job">
+        <h3>Gedanken (GCertifica) — Product Manager</h3>
+        <span class="meta">mai/2022 – nov/2024 · São Paulo</span>
+        <ul>
+          <li>Redesenho de onboarding e base de conhecimento para autosserviço.</li>
+          <li>Experimentos contínuos no funil e análises por grupos de usuários.</li>
+          <li>Resultados: −70% TTFV, −50% tickets, melhora de retenção e NPS.</li>
+        </ul>
+      </article>
+      <article class="job">
+        <h3>Se Liga (EdTech) — Product Manager</h3>
+        <span class="meta">jul/2017 – mai/2022 · B2C assinatura</span>
+        <ul>
+          <li>Migração de conteúdo aberto para modelo recorrente e construção do LMS.</li>
+          <li>Otimização de landing e fluxo de conversão; rituais de uso para retenção.</li>
+          <li>Resultados: 10k+ alunos com operação sustentável.</li>
+        </ul>
+      </article>
+    </section>
+    <section id="education">
+      <h2>Formação Acadêmica</h2>
+      <ul>
+        <li>Pós-Graduação em Liderança e Gestão de Pessoas — Descomplica, 2023</li>
+        <li>Pós-Graduação em Gestão de Produtos — Descomplica, 2022</li>
+        <li>MBA em Gestão Estratégica de Projetos e Metodologias Ágeis — Descomplica, 2022</li>
+        <li>Graduação em Publicidade e Propaganda — Belas Artes, 2009</li>
+        <li>Ensino Médio Técnico em Tecnologia da Informação — ETEC Camargo Aranha, 2004</li>
+      </ul>
+    </section>
+    <section id="skills">
+      <h2>Competências & Ferramentas</h2>
+      <ul>
+        <li>Produto: discovery, roadmap, priorização por impacto, OKRs.</li>
+        <li>Métricas: aquisição, ativação, engajamento, retenção.</li>
+        <li>Experimentos: testes A/B leves, hipóteses simples, aprendizagem rápida.</li>
+        <li>Dados & Martech: GA4/BigQuery, Amplitude/Segment, HubSpot/RD.</li>
+        <li>UX & Operação: Figma, Miro, Jira, Zendesk.</li>
+      </ul>
+    </section>
+    <section id="certifications">
+      <h2>Certificações</h2>
+      <ul>
+        <li>CSPO — K21</li>
+        <li>Digital Product Leadership — TERA</li>
+        <li>Inteligência Artificial em Negócios Digitais — TERA</li>
+      </ul>
+    </section>
+    <section id="languages">
+      <h2>Idiomas</h2>
+      <p>Inglês: Avançado</p>
+      <p>Espanhol: Intermediário</p>
+    </section>
+  </main>
+</body>
+</html>

--- a/SeniorProductManager_v2.html
+++ b/SeniorProductManager_v2.html
@@ -1,0 +1,84 @@
+<!DOCTYPE html>
+<html lang="pt-BR">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>Peter Mac Hamilton - CV v2</title>
+  <link rel="stylesheet" href="style_v2.css">
+</head>
+<body class="cv2">
+  <div class="wrapper">
+    <aside class="sidebar">
+      <h1>Peter Mac Hamilton</h1>
+      <p>São Paulo, SP</p>
+      <p>11 96953-4105</p>
+      <p><a href="mailto:novoemaildopeter@gmail.com">novoemaildopeter@gmail.com</a></p>
+      <p><a href="https://www.linkedin.com/in/peter-mac-hamilton" target="_blank">LinkedIn</a></p>
+      <h2>Competências</h2>
+      <ul class="skills">
+        <li>Discovery & Estratégia</li>
+        <li>Métricas & OKRs</li>
+        <li>Experimentação</li>
+        <li>Dados & UX</li>
+      </ul>
+      <h2>Idiomas</h2>
+      <p>Inglês: Avançado</p>
+      <p>Espanhol: Intermediário</p>
+    </aside>
+    <main class="content">
+      <section id="summary">
+        <h2>Resumo</h2>
+        <p>PM Sênior em produtos digitais com atuação end-to-end. Uso dados e UX para priorizar impacto e otimizar o funil com experimentos leves.</p>
+      </section>
+      <section id="experience">
+        <h2>Experiência</h2>
+        <article class="job">
+          <h3>PremieRpet — Senior Product Manager</h3>
+          <span class="meta">nov/2024 – presente · São Paulo</span>
+          <ul>
+            <li>Defini métricas de sucesso claras e backlog de experimentos.</li>
+            <li>Trabalho integrado com UX, dados, marketing e engenharia.</li>
+            <li>Integrações com CRM e automação para lifecycle completo.</li>
+          </ul>
+        </article>
+        <article class="job">
+          <h3>Gedanken (GCertifica) — Product Manager</h3>
+          <span class="meta">mai/2022 – nov/2024 · São Paulo</span>
+          <ul>
+            <li>Redesenho de onboarding e autosserviço via base de conhecimento.</li>
+            <li>Experimentos no funil com análises por grupos de usuários.</li>
+            <li>Resultados: −70% TTFV, −50% tickets, melhora de retenção e NPS.</li>
+          </ul>
+        </article>
+        <article class="job">
+          <h3>Se Liga (EdTech) — Product Manager</h3>
+          <span class="meta">jul/2017 – mai/2022 · B2C assinatura</span>
+          <ul>
+            <li>Migração para modelo recorrente e construção do LMS.</li>
+            <li>Otimização de landing e fluxo de conversão com rituais de uso.</li>
+            <li>Resultados: 10k+ alunos com operação sustentável.</li>
+          </ul>
+        </article>
+      </section>
+      <section id="education">
+        <h2>Formação</h2>
+        <ul>
+          <li>Pós-Graduação em Liderança e Gestão de Pessoas — Descomplica, 2023</li>
+          <li>Pós-Graduação em Gestão de Produtos — Descomplica, 2022</li>
+          <li>MBA em Gestão Estratégica de Projetos e Metodologias Ágeis — Descomplica, 2022</li>
+          <li>Graduação em Publicidade e Propaganda — Belas Artes, 2009</li>
+          <li>Ensino Médio Técnico em Tecnologia da Informação — ETEC Camargo Aranha, 2004</li>
+        </ul>
+      </section>
+      <section id="certs">
+        <h2>Certificações</h2>
+        <ul>
+          <li>CSPO — K21</li>
+          <li>Digital Product Leadership — TERA</li>
+          <li>Inteligência Artificial em Negócios Digitais — TERA</li>
+        </ul>
+      </section>
+    </main>
+  </div>
+</body>
+</html>

--- a/style_v1.css
+++ b/style_v1.css
@@ -1,0 +1,65 @@
+:root {
+  --bg: #f9f9f9;
+  --accent: #1e90ff;
+  --text: #333;
+}
+body.cv {
+  font-family: 'Inter', sans-serif;
+  background: var(--bg);
+  color: var(--text);
+  line-height: 1.6;
+  margin: 0;
+}
+.hero {
+  text-align: center;
+  padding: 2rem 1rem;
+  background: #fff;
+  border-bottom: 4px solid var(--accent);
+}
+.hero h1 {
+  font-size: 2.2rem;
+  margin: 0;
+  color: var(--accent);
+}
+.hero .tagline {
+  font-size: 1.1rem;
+  margin-top: 0.25rem;
+}
+.hero .contact, .hero .links {
+  margin-top: 0.5rem;
+}
+main {
+  max-width: 800px;
+  margin: 2rem auto;
+  padding: 0 1rem;
+}
+section {
+  margin-bottom: 2rem;
+}
+section h2 {
+  color: var(--accent);
+  border-bottom: 2px solid var(--accent);
+  padding-bottom: 0.25rem;
+  margin-bottom: 1rem;
+}
+.job {
+  margin-bottom: 1.5rem;
+}
+.job h3 {
+  margin-bottom: 0.25rem;
+  font-size: 1.05rem;
+}
+.job .meta {
+  font-size: 0.9rem;
+  color: #555;
+}
+ul {
+  padding-left: 1.25rem;
+}
+a {
+  color: var(--accent);
+  text-decoration: none;
+}
+a:hover {
+  text-decoration: underline;
+}

--- a/style_v2.css
+++ b/style_v2.css
@@ -1,0 +1,69 @@
+:root {
+  --bg: #ffffff;
+  --accent: #2e9cca;
+  --text: #222;
+  --sidebar-bg: #f4f4f4;
+}
+body.cv2 {
+  font-family: 'Inter', sans-serif;
+  background: var(--bg);
+  color: var(--text);
+  margin: 0;
+}
+.wrapper {
+  display: flex;
+  min-height: 100vh;
+}
+.sidebar {
+  width: 260px;
+  background: var(--sidebar-bg);
+  padding: 2rem 1rem;
+}
+.sidebar h1 {
+  font-size: 1.6rem;
+  margin-bottom: 1rem;
+  color: var(--accent);
+}
+.sidebar h2 {
+  margin-top: 2rem;
+  font-size: 1.1rem;
+  color: var(--accent);
+}
+.sidebar a {
+  color: var(--accent);
+  text-decoration: none;
+}
+.sidebar ul {
+  list-style: none;
+  padding-left: 0;
+}
+.sidebar ul li {
+  margin-bottom: 0.5rem;
+}
+.content {
+  flex: 1;
+  padding: 2rem 3rem;
+}
+.content section {
+  margin-bottom: 2rem;
+}
+.content h2 {
+  color: var(--accent);
+  border-bottom: 2px solid var(--accent);
+  padding-bottom: 0.25rem;
+  margin-bottom: 1rem;
+}
+.job {
+  margin-bottom: 1.5rem;
+}
+.job h3 {
+  font-size: 1.05rem;
+  margin-bottom: 0.25rem;
+}
+.job .meta {
+  font-size: 0.9rem;
+  color: #555;
+}
+ul {
+  padding-left: 1.25rem;
+}


### PR DESCRIPTION
## Summary
- add SeniorProductManager_v1 with modern single-column layout
- add SeniorProductManager_v2 with sidebar-based design
- create matching CSS themes (style_v1.css, style_v2.css)

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68bb308432f0832e80ee2222072c49cd