### PR TITLE
fix: add cv-page class to index pages

### DIFF
--- a/index-br.html
+++ b/index-br.html
@@ -6,7 +6,7 @@
     <title>Currículo de Peter Mac Hamilton</title>
     <link rel="stylesheet" href="style.css">
 </head>
-<body>
+ <body class="cv-page">
     <div class="container">
         <header>
             <h1>Peter Mac Hamilton</h1>

--- a/index-custom-gpm.html
+++ b/index-custom-gpm.html
@@ -6,7 +6,7 @@
     <title>Currículo de Peter Mac Hamilton</title>
     <link rel="stylesheet" href="style.css">
 </head>
-<body>
+ <body class="cv-page">
     <div class="container">
         <header>
             <h1>Peter Mac Hamilton</h1>

--- a/index-custom.html
+++ b/index-custom.html
@@ -7,7 +7,7 @@
     <link rel="stylesheet" href="style.css">
     <link rel="icon" href="img/favicon.ico" type="image/x-icon"> <!-- Caminho para o ícone -->
 </head>
-<body>
+ <body class="cv-page">
     <div class="container">
         <header>
             <h1>Peter Mac Hamilton</h1>

--- a/index.html
+++ b/index.html
@@ -17,7 +17,7 @@
         }
     </script>
 </head>
-<body>
+    <body class="cv-page">
     <div class="container">
         <!-- Switch de Idioma -->
         <header>


### PR DESCRIPTION
## Summary
- ensure index.html, index-br.html and custom index pages include `class="cv-page"` on the `<body>` element so style_2 styles apply correctly

## Testing
- `npm test` *(fails: Could not read package.json)*
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68bb30af84c4832e8f8a31dd8a3f09af